### PR TITLE
fix Message Class

### DIFF
--- a/lib/Bot.js
+++ b/lib/Bot.js
@@ -79,7 +79,9 @@ class Bot extends EventEmitter {
   }
 
   _sendWeb(msg, cb) {
-    msg.as_user = true;
+    if (!('as_user' in msg)) {
+      msg.as_user = true;
+    }
     this._client.web.chat.postMessage(msg.channel, undefined, msg, cb);
   }
 

--- a/lib/Message.js
+++ b/lib/Message.js
@@ -4,7 +4,7 @@ class Message {
   constructor(bot, msg) {
     this._bot = bot;
     this._msg = msg;
-    this.text = msg.text.replace(/^<@.+?> /, '');
+    this.text = msg.text.replace(/^<@.+?>:? /, '');
     this.user = clone( bot.data.users.filter((u) => u.id === msg.user)[0] );
   }
 


### PR DESCRIPTION
モバイルアプリからbotに対してチャネル名を含めたメッセージを送信した場合、正規表現により展開されたチャネル名の `>` までの文字列を置換してしまう為、  
`@bot >: message` の `:` を含めた形で正規表現を修正しました。